### PR TITLE
Set node-gyp version to 8.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "fs": "0.0.1-security",
     "http": "0.0.0",
-    "node-gyp": "",
+    "node-gyp": "8.4.1",
     "path": "^0.12.7",
     "websocket": "^1.0.25"
   },


### PR DESCRIPTION
# Description
Update node-gyp version to 8.4.1 to prevent auto downloading of version 9.0.0 as versions > 8.4.1 is not compatible